### PR TITLE
[PIZ1]: I cant create an order

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,11 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route('/', methods=GET)
+def get_sizes():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -1,0 +1,39 @@
+import pytest
+
+from app.test.utils.functions import get_random_string, get_random_price
+
+
+def test_create_size_service(create_size):
+    size = create_size.json
+    pytest.assume(create_size.status.startswith('200'))
+    pytest.assume(size['_id'])
+    pytest.assume(size['name'])
+    pytest.assume(size['price'])
+
+
+def test_update_size_service(client, create_size, size_uri):
+    current_size = create_size.json
+    update_data = {**current_size, 'name': get_random_string(),
+                   'price': get_random_price(1, 5)}
+    response = client.put(size_uri, json=update_data)
+    pytest.assume(response.status.startswith('200'))
+    updated_size = response.json
+    for param, value in update_data.items():
+        pytest.assume(updated_size[param] == value)
+
+
+def test_get_size_by_id_service(client, create_size, size_uri):
+    current_size = create_size.json
+    response = client.get(f'{size_uri}id/{current_size["_id"]}')
+    pytest.assume(response.status.startswith('200'))
+    returned_size = response.json
+    for param, value in current_size.items():
+        pytest.assume(returned_size[param] == value)
+
+
+def test_get_sizes_service(client, create_sizes, size_uri):
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith('200'))
+    returned_sizes = {size['_id']: size for size in response.json}
+    for size in create_sizes:
+        pytest.assume(size['_id'] in returned_sizes)


### PR DESCRIPTION
**Requirement:**
During order creation. I'm unable to complete the order. Moreover, I can't see the pizza sizes. I think that's the problem, as I can't choose the sizes, the order is not created. Please help me to figure out the bug.

**What was done:**
- Created tests for size services
- Added get_sizes method to size services

**Captures**:
Sizes being read in the order tab:
![image](https://user-images.githubusercontent.com/44239094/200403664-8f45cd2e-959d-451b-bdf9-16bcc86d2ff5.png)

Orders created:
![image](https://user-images.githubusercontent.com/44239094/200403825-591d8c01-02a1-4cad-8018-df2c66608751.png)

Sizes created:
![image](https://user-images.githubusercontent.com/44239094/200403902-14d4beac-89ca-4526-8344-7370fefecadb.png)

