### PR TITLE
[PIZ4.1] Create a CI job with GitHub actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -11,17 +11,16 @@ jobs:
       matrix:
         python-version: ["3.8"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-            python -m pip install --upgrade pip
-            pip install -r ./requirements.txt
-    - name: Analysing the code with flake 8
-      run: |
-            flake8
-    - name: Run tests with pytest
-      run: pytest
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./requirements.txt
+      - name: Run tests with pytest and create coverage report
+        run: coverage run -m pytest
+      - name: Show coverage report
+        run: coverage report -m

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+            python -m pip install --upgrade pip
+            pip install -r ./requirements.txt
+    - name: Analysing the code with flake 8
+      run: |
+            flake8
+    - name: Run tests with pytest
+      run: pytest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TEST_DIR: app/test/
     strategy:
       matrix:
         python-version: ["3.8"]
@@ -21,8 +23,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Run tests with pytest and create coverage report
-        run: pytest-
+      - name: Test with pytest
+        working-directory: ./${{ env.TEST_DIR }}
+        run: |
+          python -m pytest -v
       - name: Build coverage file
         run: |
           pytest --cache-clear --cov=app ./${{ env.TEST_DIR }} > pytest-coverage.txt

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,9 +22,9 @@ jobs:
           pip install flake8 pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run tests with pytest and create coverage report
-        run: pytest
+        run: pytest-
       - name: Build coverage file
         run: |
-          pytest --cache-clear --cov=app test/ > pytest-coverage.txt
+          pytest --cache-clear --cov=app ./${{ env.TEST_DIR }} > pytest-coverage.txt
       - name: Comment coverage
         uses: coroo/pytest-coverage-commentator@v1.0.2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,8 +19,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r ./requirements.txt
+          pip install flake8 pytest pytest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run tests with pytest and create coverage report
-        run: coverage run -m pytest
-      - name: Show coverage report
-        run: coverage report -m
+        run: pytest
+      - name: Build coverage file
+        run: |
+          pytest --cache-clear --cov=app test/ > pytest-coverage.txt
+      - name: Comment coverage
+        uses: coroo/pytest-coverage-commentator@v1.0.2


### PR DESCRIPTION
**Requirements**
Create a CI job with GitHub actions to run the tests and coverage when a PR is created. We want to be sure that test coverage does not decrease with new changes.

**What was done:**

- Created .github/workflows/python.yml file for the CI job with GitHub actions
- Added Coverage report in the GitHub actions
- Added Pytest Coverage Commentator

**Captures**:
![image](https://user-images.githubusercontent.com/44239094/200633636-88a34eb7-1954-4bb8-b33d-37afdee61999.png)